### PR TITLE
Fixed annihilation field/singularity affecting wrong maps

### DIFF
--- a/Source/RimEffect/Abilities/Abilities/Ability_Annihilation.cs
+++ b/Source/RimEffect/Abilities/Abilities/Ability_Annihilation.cs
@@ -102,9 +102,9 @@
 
                 foreach (IntVec3 intVec3 in GenAdj.OccupiedRect(this.Position, this.Rotation, rangeIntVec2))
                 {
-                    if (!intVec3.InBounds(Find.CurrentMap))
+                    if (!intVec3.InBounds(this.Map))
                         continue;
-                    List<Thing> cellThings = Find.CurrentMap.thingGrid.ThingsListAt(intVec3);
+                    List<Thing> cellThings = this.Map.thingGrid.ThingsListAt(intVec3);
                     if (cellThings == null)
                         continue;
 

--- a/Source/RimEffect/Abilities/Abilities/Ability_Singularity.cs
+++ b/Source/RimEffect/Abilities/Abilities/Ability_Singularity.cs
@@ -107,9 +107,9 @@
 
                 foreach (IntVec3 intVec3 in GenAdj.OccupiedRect(this.Position, this.Rotation, rangeIntVec2))
                 {
-                    if (!intVec3.InBounds(Find.CurrentMap)) 
+                    if (!intVec3.InBounds(this.Map)) 
                         continue;
-                    List<Thing> cellThings = Find.CurrentMap.thingGrid.ThingsListAt(intVec3);
+                    List<Thing> cellThings = this.Map.thingGrid.ThingsListAt(intVec3);
                     if (cellThings == null) 
                         continue;
                     


### PR DESCRIPTION
Right now, those 2 abilities use Find.CurrentMap, which is the map the player is on - not the abilities. This allowed those abilities to affect different maps instead of the one they were cast on by just switching the map the player is on.

This fixes this issue by using the actual map they're located on.