### PR TITLE
Fixed abilities applying hediffs

### DIFF
--- a/1.3/Defs/Abilities/Biotic/Abilities.xml
+++ b/1.3/Defs/Abilities/Biotic/Abilities.xml
@@ -73,6 +73,7 @@
     <abilityClass>RimEffect.Ability_Pull</abilityClass>
     <targetMode>Pawn</targetMode>
     <castTime>60</castTime>
+    <durationTime>600</durationTime>
     <range>24</range>
 	<castSound>RE_Biotic_Pull</castSound>
     <iconPath>UI/Abilities/Biotic_Pull</iconPath>
@@ -99,9 +100,7 @@
     <labelNoun>knocked prone</labelNoun>
     <description>Knocked prone.</description>
     <comps>
-      <li Class="HediffCompProperties_Disappears">
-        <disappearsAfterTicks>600~600</disappearsAfterTicks>
-      </li>
+      <li Class="HediffCompProperties_Disappears"/>
       <li Class="HediffCompProperties_Effecter">
         <stateEffecter>RE_Dominate</stateEffecter>
       </li>

--- a/1.3/Defs/Abilities/Spectre/Abilities.xml
+++ b/1.3/Defs/Abilities/Spectre/Abilities.xml
@@ -8,6 +8,7 @@
         <targetMode>Self</targetMode>
         <castTime>30</castTime>
         <cooldownTime>3600</cooldownTime>
+        <durationTime>600</durationTime>
         <iconPath>UI/Abilities/Ability_AdrenalineRush</iconPath>
         <modExtensions>
             <li Class="VFECore.Abilities.AbilityExtension_Hediff">
@@ -22,9 +23,7 @@
         <labelNoun>an adrenaline rush</labelNoun>
         <description>Gives the wearer an adrenaline rush</description>
         <comps>
-            <li Class="HediffCompProperties_Disappears">
-                <disappearsAfterTicks>600~600</disappearsAfterTicks>
-            </li>
+            <li Class="HediffCompProperties_Disappears"/>
         </comps>
         <stages>
             <li>
@@ -46,6 +45,7 @@
         <targetMode>Self</targetMode>
         <castTime>30</castTime>
         <cooldownTime>3600</cooldownTime>
+        <durationTime>600</durationTime>
         <iconPath>UI/Abilities/Ability_CombatMastery</iconPath>
         <modExtensions>
             <li Class="VFECore.Abilities.AbilityExtension_Hediff">
@@ -60,9 +60,7 @@
         <labelNoun>an increased accuracy</labelNoun>
         <description>Gives the wearer increased accuracy</description>
         <comps>
-            <li Class="HediffCompProperties_Disappears">
-                <disappearsAfterTicks>600~600</disappearsAfterTicks>
-            </li>
+            <li Class="HediffCompProperties_Disappears"/>
         </comps>
         <stages>
             <li>

--- a/1.3/Defs/Abilities/Tech/Abilities.xml
+++ b/1.3/Defs/Abilities/Tech/Abilities.xml
@@ -286,6 +286,7 @@
     <cooldownTimeStatFactors>
       <RE_AbilityCooldownFactor>1</RE_AbilityCooldownFactor>
     </cooldownTimeStatFactors>
+    <durationTime>1800</durationTime>
     <iconPath>UI/Abilities/Tech_TacticalCloak</iconPath>
 	<castSound>RE_Tech_TacticalCloak</castSound>
     <requiredHediff>
@@ -306,9 +307,7 @@
     <hediffClass>HediffWithComps</hediffClass>
     <isBad>false</isBad>
     <comps>
-      <li Class="HediffCompProperties_Disappears">
-        <disappearsAfterTicks>1800~1800</disappearsAfterTicks>
-      </li>
+      <li Class="HediffCompProperties_Disappears"/>
       <li Class="HediffCompProperties">
         <compClass>HediffComp_Invisibility</compClass>
       </li>


### PR DESCRIPTION
Looking at `VFECore.Abilities.Ability:ApplyHediff`, it uses `durationTime` and applies it to `HediffCompProperties_Disappears`, even if `durationTime` is 0. I believe this was changed at some point, but those abilities and hediffs weren't updated for that.

This also affects Rim-Effect: N7, for which I've also made a PR.

Rim-Effect: Asari and Reapers also suffers from this, however I am unable to make a PR because as far as I'm aware it's not on GitHub (or not as easy to find as the rest of the mods).